### PR TITLE
Update setOrder plugins signature

### DIFF
--- a/Plugin/Model/ResourceModel/Product/CollectionPlugin.php
+++ b/Plugin/Model/ResourceModel/Product/CollectionPlugin.php
@@ -27,7 +27,7 @@ class CollectionPlugin
     public function beforeSetOrder(
         Collection $subject,
         $attribute,
-        string $dir = Select::SQL_DESC
+        $dir = Select::SQL_DESC
     ): array {
         $subject->setFlag('is_processing', true);
         $this->applyOutOfStockAtLastOrders($subject);
@@ -68,7 +68,7 @@ class CollectionPlugin
         Collection $subject,
         callable $proceed,
         $attribute,
-        string $dir = Select::SQL_DESC
+        $dir = Select::SQL_DESC
     ): Collection {
         $flagName = $this->_getFlag($attribute);
         if (!in_array($flagName, $this->skipFlags)) {


### PR DESCRIPTION
Despite magento documented desc as string in phpdoc, it is not typed in param signature. In one of the elasticsuite plugin, it passes array to the setOrder
https://github.com/Smile-SA/elasticsuite/blob/affec096d16194addea273dfa35145a42da4213a/src/module-elasticsuite-virtual-category/Plugin/Widget/ProductsListPlugin.php#L152
as you can see the array is assembled here
https://github.com/Smile-SA/elasticsuite/blob/affec096d16194addea273dfa35145a42da4213a/src/module-elasticsuite-virtual-category/Model/Widget/SortOrder/SkuPosition/Builder.php#L63

So to maintain compatibility with elasticsuite for now, we have to remove the string type, other wise it breaks website if there is a product list widget created.