### PR TITLE
Fix Magento 2 Integration Tests

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,10 +1,39 @@
 name: ExtDN M2 Integration Tests
-on: [ push, pull_request ]
+on: [ pull_request ]
 
 jobs:
+  mage248:
+    name: Magento 2 Integration Tests (Magento v2.4.8)
+    runs-on: ubuntu-22.04
+    services:
+      mysql:
+        image: mysql:8.0
+        env:
+          MYSQL_ROOT_PASSWORD: root
+        ports:
+          - 3306:3306
+        options: --tmpfs /tmp:rw --tmpfs /var/lib/mysql:rw --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+      es:
+        image: docker.io/wardenenv/elasticsearch:8.1
+        ports:
+          - 9200:9200
+        env:
+          'discovery.type': single-node
+          'xpack.security.enabled': false
+          ES_JAVA_OPTS: "-Xms64m -Xmx512m"
+        options: --health-cmd="curl localhost:9200/_cluster/health?wait_for_status=yellow&timeout=60s" --health-interval=10s --health-timeout=5s --health-retries=3
+    steps:
+      - uses: actions/checkout@v2
+      - name: M2 Integration Tests with Magento 2
+        uses: extdn/github-actions-m2/magento-integration-tests/8.4@master
+        with:
+          module_name: GhoSter_OutOfStockAtLast
+          composer_name: ghoster/module-outofstockatlast
+          ce_version: 2.4.8
+          block_insecure: false
   mage247:
     name: Magento 2 Integration Tests (Magento v2.4.7)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     services:
       mysql:
         image: mysql:8.0
@@ -30,10 +59,11 @@ jobs:
           module_name: GhoSter_OutOfStockAtLast
           composer_name: ghoster/module-outofstockatlast
           ce_version: 2.4.7
+          block_insecure: false
 
   mage246:
     name: Magento 2 Integration Tests (Magento v2.4.6)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     services:
       mysql:
         image: mysql:8.0
@@ -59,10 +89,11 @@ jobs:
           module_name: GhoSter_OutOfStockAtLast
           composer_name: ghoster/module-outofstockatlast
           ce_version: 2.4.6
+          block_insecure: false
 
   mage244:
     name: Magento 2 Integration Tests (Magento v2.4.4)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     services:
       mysql:
         image: mysql:8.0
@@ -88,10 +119,11 @@ jobs:
           module_name: GhoSter_OutOfStockAtLast
           composer_name: ghoster/module-outofstockatlast
           ce_version: 2.4.4
+          block_insecure: false
 
   mage24:
     name: Magento 2 Integration Tests (Magento v2.4.3)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     services:
       mysql:
         image: mysql:8.0
@@ -117,3 +149,4 @@ jobs:
           module_name: GhoSter_OutOfStockAtLast
           composer_name: ghoster/module-outofstockatlast
           ce_version: 2.4.3
+          block_insecure: false

--- a/README.md
+++ b/README.md
@@ -18,23 +18,24 @@
 - Sort Out Of Stock Product At last the product list
 - Compatibility with `smile/elasticsuite^2.11`
 - Firstly `Display Out of Stock Products` from `Stores > Configuration > Catalog > Inventory > Stock Options` must be set `Yes`
-- Of course, we are talking about Elastic Search. We don't support **old search engine**
+- Of course, we are talking about ElasticSearch or OpenSearch. We don't support **old search engine**
 - From time to time we remind you **Reindexing after you enable the module**
 
 
 ## Compatibility
 
 | Magento Version (Open Source/Commerce) | Elasticsearch | OpenSearch | ElasticSuite | Supported |
-| -------------------------------------- | ------------- | ---------- | ------------ | --------- |
-| **2.0.x**                              | 2.x           | -          | 2.1.x        | No ❌      |
-| **2.1.x**                              | 2.x & 5.x     | -          | 2.3.x        | No ❌      |
-| **2.2.x**                              | 5.x & 6.x     | -          | 2.6.x        | No ❌      |
-| **<2.3.2**                             | 5.x & 6.x     | -          | 2.8.4        | No ❌      |
-| **<2.3.5**                             | 5.x & 6.x     | -          | 2.8.x        | No ❌      |
-| **>=2.3.5**                            | 6.x & 7.x     | -          | 2.9.x        | No ❌      |
-| **2.4.0**                              | 6.x & 7.x     | -          | 2.10.1       | Yes ✔️     |
-| **>=2.4.1 && < 2.4.6**                 | 6.x & 7.x     | -          | 2.10.x       | Yes ✔️     |
-| **>=2.4.6**                            | 7.x & 8.x     | 1.x & 2.x  | >=2.11.x     | Yes ✔️     |
+|--------------------------------------|---------------|------------|--------------| --------- |
+| **2.0.x**                            | 2.x           | -          | 2.1.x        | No ❌      |
+| **2.1.x**                            | 2.x & 5.x     | -          | 2.3.x        | No ❌      |
+| **2.2.x**                            | 5.x & 6.x     | -          | 2.6.x        | No ❌      |
+| **<2.3.2**                           | 5.x & 6.x     | -          | 2.8.4        | No ❌      |
+| **<2.3.5**                           | 5.x & 6.x     | -          | 2.8.x        | No ❌      |
+| **>=2.3.5**                          | 6.x & 7.x     | -          | 2.9.x        | No ❌      |
+| **2.4.0**                            | 6.x & 7.x     | -          | 2.10.1       | Yes ✔️     |
+| **>=2.4.1 && < 2.4.6**               | 6.x & 7.x     | -          | 2.10.x       | Yes ✔️     |
+| **>=2.4.6 && < 2.4.8                 | 7.x & 8.x     | 1.x & 2.x  | >=2.11.x     | Yes ✔️     |
+| **>=2.4.8**                          | -             | 3.x        | >=2.11.13    | Yes ✔️     |
 
 
 

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "ghoster/module-outofstockatlast",
     "description": "Magento 2.4.x module Sort Out Of Stock Product At last the product list",
     "require": {
-        "php": ">=8.1.0",
+        "php": ">=7.4",
         "magento/framework": ">=102.0.0"
     },
     "minimum-stability": "stable",


### PR DESCRIPTION
Fix Magento 2 Integration Tests caused by Ubuntu specific version

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated search engine compatibility documentation to include OpenSearch alongside ElasticSearch
  * Expanded Magento version compatibility matrix with dedicated Magento 2.4.8 configuration and refined version-specific requirements

* **Chores**
  * Relaxed minimum PHP version requirement from 8.1 to 7.4

<!-- end of auto-generated comment: release notes by coderabbit.ai -->