### PR TITLE
Fix GraphQl relevant missmatch while perform searching on graphql

### DIFF
--- a/.github/workflows/coding-standard.yml
+++ b/.github/workflows/coding-standard.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   static:
     name: M2 Coding Standard
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
-      - uses: extdn/github-actions-m2/magento-coding-standard@master
+      - uses: actions/checkout@v7
+      - uses: extdn/github-actions-m2/magento-coding-standard/8.4@master

--- a/Plugin/DataProvider/Product/SearchCriteriaBuilder/AddDefaultOrders.php
+++ b/Plugin/DataProvider/Product/SearchCriteriaBuilder/AddDefaultOrders.php
@@ -2,34 +2,60 @@
 namespace GhoSter\OutOfStockAtLast\Plugin\DataProvider\Product\SearchCriteriaBuilder;
 
 use GhoSter\OutOfStockAtLast\Model\AdditionalAttribute;
+use Magento\CatalogGraphQl\DataProvider\Product\SearchCriteriaBuilder;
+use Magento\Framework\Api\Search\SearchCriteriaInterface;
+use Magento\Framework\Api\SortOrder;
+use Magento\Framework\Api\SortOrderBuilder;
 
 class AddDefaultOrders
 {
     /**
-     * Add default sorting
+     * @var SortOrderBuilder
+     */
+    private $sortOrderBuilder;
+
+    /**
+     * @param SortOrderBuilder $sortOrderBuilder
+     */
+    public function __construct(
+        SortOrderBuilder $sortOrderBuilder
+    ) {
+        $this->sortOrderBuilder = $sortOrderBuilder;
+    }
+
+    /**
+     * Add default sorting.
      *
-     * phpcs:disable Magento2.Annotation.MethodArguments.NoTypeSpecified
-     *
-     * @param $subject
+     * @param SearchCriteriaBuilder $subject
+     * @param SearchCriteriaInterface $searchCriteria
      * @param array $args
      * @param bool $includeAggregation
-     * @return array
+     *
+     * @return SearchCriteriaInterface
+     * @see \Magento\CatalogGraphQl\DataProvider\Product\SearchCriteriaBuilder::build
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function beforeBuild(
-        $subject,
+    public function afterBuild(
+        SearchCriteriaBuilder $subject,
+        SearchCriteriaInterface $searchCriteria,
         array $args,
         bool $includeAggregation
-    ): array {
-        if (!isset($args['sort'])) {
-            $args['sort'] = [];
+    ): SearchCriteriaInterface {
+        $sortOrders = $searchCriteria->getSortOrders();
+
+        if (empty($sortOrders)) {
+            return $searchCriteria;
         }
 
-        if (!isset($args['sort'][AdditionalAttribute::ATTRIBUTE_CODE])
-        ) {
-            $args['sort'][AdditionalAttribute::ATTRIBUTE_CODE] = 'DESC';
-        }
+        $sortOrder = $this->sortOrderBuilder
+            ->setField(AdditionalAttribute::ATTRIBUTE_CODE)
+            ->setDirection(SortOrder::SORT_DESC)
+            ->create();
 
-        return [$args, $includeAggregation];
+        array_splice($sortOrders, -1, 0, [$sortOrder]);
+
+        $searchCriteria->setSortOrders($sortOrders);
+
+        return $searchCriteria;
     }
 }


### PR DESCRIPTION
- [fix] GraphQl relevant missmatch while perform searching on graphql
- [feat] bump Coding standard

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved product search sorting by consistently applying the default descending order for the relevant attribute while preserving existing sort selections.

* **Chores**
  * Updated the automated coding-standard checks and their execution environment for more consistent validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->