### PR TITLE
[fix] GraphQl relevant missmatch while perform searching on graphql

### DIFF
--- a/Plugin/DataProvider/Product/SearchCriteriaBuilder/AddDefaultOrders.php
+++ b/Plugin/DataProvider/Product/SearchCriteriaBuilder/AddDefaultOrders.php
@@ -52,7 +52,7 @@ class AddDefaultOrders
             ->setDirection(SortOrder::SORT_DESC)
             ->create();
 
-        array_splice($sortOrders, -1, 0, [$sortOrder]);
+        array_unshift($sortOrders, $sortOrder);
 
         $searchCriteria->setSortOrders($sortOrders);
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected default sorting so it consistently takes priority over other sort orders in search results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->